### PR TITLE
fix: bzanim library include comment

### DIFF
--- a/packages/bzAnim/bzAnim.bzAnim.d.ts
+++ b/packages/bzAnim/bzAnim.bzAnim.d.ts
@@ -1,5 +1,3 @@
-/// <library version="1.2.0" src="https://github.com/jbp4444/bzAnim/archive/refs/tags/v.1.2.zip" />
-
 /** @noSelfInFile **/
 
 declare type EASING_TYPES =


### PR DESCRIPTION
The type definition had an additional library include comment causing the system to deploy two typing files instead of amalgamating them into a single file.