### PR TITLE
Widen peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "typescript-to-lua": "1.1.1"
       },
       "peerDependencies": {
-        "typescript": "^4.4.4",
+        "typescript": "^4.4.4 || ^5",
         "typescript-to-lua": "^1.1.1"
       }
     },
@@ -431,9 +431,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -767,7 +767,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/lua-types/-/lua-types-2.11.0.tgz",
       "integrity": "sha512-J/8qHrOjkZuPBDhnuAg0DWoaJEImqXNzgEnUigCTVrSVCcchM5Y5zpcI3aWAZPhuZlb0QKC/f3nc7VGmZmBg7w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "mime-db": {
       "version": "1.50.0",
@@ -862,9 +863,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
     "typescript-to-lua": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript-to-lua": "1.1.1"
   },
   "peerDependencies": {
-    "typescript": "^4.4.4",
+    "typescript": "^4.4.4 || ^5",
     "typescript-to-lua": "^1.1.1"
   }
 }


### PR DESCRIPTION
ts-defold/tsd-template is currently blocked from upgrading to TypeScript v5 because of the narrow peerDependency in this project. Related to ts-defold/tsd-template#35.