### PR TITLE
Remove fixed peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "typescript-to-lua": "1.1.1"
       },
       "peerDependencies": {
-        "typescript": "^4.4.4",
         "typescript-to-lua": "^1.1.1"
       }
     },
@@ -431,9 +430,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -767,7 +766,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/lua-types/-/lua-types-2.11.0.tgz",
       "integrity": "sha512-J/8qHrOjkZuPBDhnuAg0DWoaJEImqXNzgEnUigCTVrSVCcchM5Y5zpcI3aWAZPhuZlb0QKC/f3nc7VGmZmBg7w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "mime-db": {
       "version": "1.50.0",
@@ -862,9 +862,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
     "typescript-to-lua": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "typescript-to-lua": "1.1.1"
   },
   "peerDependencies": {
-    "typescript": "^4.4.4",
     "typescript-to-lua": "^1.1.1"
   }
 }


### PR DESCRIPTION
Removes TypeScript as a fixed peer dependency.

Ongoing discussion in ts-defold/tstl-export-as-global#1

Unblocks:
- ts-defold/tsd-template#36
- ts-defold/tsd-template-yagames#19